### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: ${{inputs.git}}
           ref: ${{inputs.ref}}


### PR DESCRIPTION
I accidentally removed the checkout action thinking it is in there twice.
I entirely missed that the second invocation checks out something different!